### PR TITLE
Update keywords and add ebuilds for keyboard and mouse drivers

### DIFF
--- a/x11-base/xlibre-drivers/xlibre-drivers-9999.ebuild
+++ b/x11-base/xlibre-drivers/xlibre-drivers-9999.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="No_homepage"
 LICENSE="metapackage"
 SLOT="0"
 if [[ ${PV} != 9999 ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 else
 	PROPERTIES+=" live"
 fi

--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -12,7 +12,7 @@ SLOT="0/${PV}"
 
 # This is the only ebuild for now, keep keywords
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
 IUSE_SERVERS="xephyr xnest xorg xvfb"

--- a/x11-drivers/xf86-input-elographics/xf86-input-elographics-9999.ebuild
+++ b/x11-drivers/xf86-input-elographics/xf86-input-elographics-9999.ebuild
@@ -8,5 +8,5 @@ inherit xlibre
 
 DESCRIPTION="Elographics input driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~sparc ~x86"
 fi

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
@@ -8,7 +8,7 @@ inherit linux-info xlibre
 
 DESCRIPTION="Generic Linux input driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 
 RDEPEND="

--- a/x11-drivers/xf86-input-joystick/xf86-input-joystick-9999.ebuild
+++ b/x11-drivers/xf86-input-joystick/xf86-input-joystick-9999.ebuild
@@ -8,7 +8,7 @@ inherit xlibre
 
 DESCRIPTION="XLibre driver for joystick input devices"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~ppc ~ppc64 ~sparc ~x86"
 fi
 
 src_install() {

--- a/x11-drivers/xf86-input-keyboard/metadata.xml
+++ b/x11-drivers/xf86-input-keyboard/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>maintainer-needed@example.com</email>
+    <name>XLibre</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">X11Libre/xf86-input-keyboard</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/x11-drivers/xf86-input-keyboard/xf86-input-keyboard-9999.ebuild
+++ b/x11-drivers/xf86-input-keyboard/xf86-input-keyboard-9999.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xlibre
+
+DESCRIPTION="Keyboard input driver"
+if [[ ${PV} != 9999* ]]; then
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+fi
+
+RDEPEND="x11-base/xlibre-server"
+DEPEND="${RDEPEND}"

--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-9999.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-9999.ebuild
@@ -8,7 +8,7 @@ inherit linux-info xlibre
 
 DESCRIPTION="XLibre input driver based on libinput"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 RDEPEND=">=dev-libs/libinput-1.23.0:0="

--- a/x11-drivers/xf86-input-mouse/metadata.xml
+++ b/x11-drivers/xf86-input-mouse/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>maintainer-needed@example.com</email>
+    <name>XLibre</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">X11Libre/xf86-input-mouse</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/x11-drivers/xf86-input-mouse/xf86-input-mouse-9999.ebuild
+++ b/x11-drivers/xf86-input-mouse/xf86-input-mouse-9999.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xlibre
+
+DESCRIPTION="Mouse input driver"
+if [[ ${PV} != 9999* ]]; then
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+fi
+
+RDEPEND="x11-base/xlibre-server"
+DEPEND="${RDEPEND}"

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-9999.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-9999.ebuild
@@ -8,7 +8,7 @@ inherit linux-info xlibre
 
 DESCRIPTION="Driver for Synaptics touchpads"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~x86"
 fi
 
 RDEPEND="

--- a/x11-drivers/xf86-input-vmmouse/xf86-input-vmmouse-9999.ebuild
+++ b/x11-drivers/xf86-input-vmmouse/xf86-input-vmmouse-9999.ebuild
@@ -7,7 +7,7 @@ inherit udev xlibre
 
 DESCRIPTION="VMWare mouse input driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 DEPEND="x11-base/xorg-proto"

--- a/x11-drivers/xf86-input-wacom/xf86-input-wacom-9999.ebuild
+++ b/x11-drivers/xf86-input-wacom/xf86-input-wacom-9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://linuxwacom.github.io/"
 
 LICENSE="GPL-2+"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 IUSE="test"
 RESTRICT="!test? ( test )"

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -7,7 +7,7 @@ XLIBRE_DRI="always"
 inherit xlibre
 
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"

--- a/x11-drivers/xf86-video-ast/xf86-video-ast-9999.ebuild
+++ b/x11-drivers/xf86-video-ast/xf86-video-ast-9999.ebuild
@@ -8,5 +8,5 @@ inherit xlibre
 
 DESCRIPTION="XLibre driver for ASpeedTech cards"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~loong ~ppc ~ppc64 ~x86"
 fi

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-9999.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-9999.ebuild
@@ -8,7 +8,7 @@ XLIBRE_DRI=always
 inherit linux-info xlibre
 
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 
 DESCRIPTION="ATI video driver"

--- a/x11-drivers/xf86-video-dummy/xf86-video-dummy-9999.ebuild
+++ b/x11-drivers/xf86-video-dummy/xf86-video-dummy-9999.ebuild
@@ -8,5 +8,5 @@ inherit xlibre
 
 DESCRIPTION="XLibre driver for dummy cards"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi

--- a/x11-drivers/xf86-video-fbdev/xf86-video-fbdev-9999.ebuild
+++ b/x11-drivers/xf86-video-fbdev/xf86-video-fbdev-9999.ebuild
@@ -7,5 +7,5 @@ inherit xlibre
 
 DESCRIPTION="video driver for framebuffer device"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi

--- a/x11-drivers/xf86-video-geode/xf86-video-geode-9999.ebuild
+++ b/x11-drivers/xf86-video-geode/xf86-video-geode-9999.ebuild
@@ -8,7 +8,7 @@ inherit xlibre
 
 DESCRIPTION="AMD Geode GX and LX graphics driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~x86"
 fi
 IUSE="ztv"
 

--- a/x11-drivers/xf86-video-intel/xf86-video-intel-9999.ebuild
+++ b/x11-drivers/xf86-video-intel/xf86-video-intel-9999.ebuild
@@ -9,7 +9,7 @@ XLIBRE_EAUTORECONF=yes
 inherit linux-info xlibre flag-o-matic
 
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="XLibre driver for Intel cards"

--- a/x11-drivers/xf86-video-mga/xf86-video-mga-9999.ebuild
+++ b/x11-drivers/xf86-video-mga/xf86-video-mga-9999.ebuild
@@ -8,7 +8,7 @@ inherit xlibre
 
 DESCRIPTION="Matrox video driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~loong ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
 src_configure() {

--- a/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-9999.ebuild
+++ b/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-9999.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/X11Libre/xf86-video-nouveau
 "
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 RDEPEND=">=x11-libs/libdrm-2.4.60[video_cards_nouveau]

--- a/x11-drivers/xf86-video-qxl/xf86-video-qxl-9999.ebuild
+++ b/x11-drivers/xf86-video-qxl/xf86-video-qxl-9999.ebuild
@@ -9,7 +9,7 @@ inherit python-single-r1 xlibre
 
 DESCRIPTION="QEMU QXL paravirt video driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~loong ~x86"
 fi
 IUSE="xspice"
 REQUIRED_USE="xspice? ( ${PYTHON_REQUIRED_USE} )"

--- a/x11-drivers/xf86-video-r128/xf86-video-r128-9999.ebuild
+++ b/x11-drivers/xf86-video-r128/xf86-video-r128-9999.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic xlibre
 
 DESCRIPTION="ATI Rage128 video driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~loong ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
 src_configure() {

--- a/x11-drivers/xf86-video-siliconmotion/xf86-video-siliconmotion-9999.ebuild
+++ b/x11-drivers/xf86-video-siliconmotion/xf86-video-siliconmotion-9999.ebuild
@@ -8,5 +8,5 @@ inherit xlibre
 
 DESCRIPTION="Silicon Motion video driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~mips ~x86"
 fi

--- a/x11-drivers/xf86-video-vesa/xf86-video-vesa-9999.ebuild
+++ b/x11-drivers/xf86-video-vesa/xf86-video-vesa-9999.ebuild
@@ -8,7 +8,7 @@ inherit linux-info xlibre
 
 DESCRIPTION="Generic VESA video driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="-* ~alpha ~amd64 ~x86"
 fi
 
 pkg_pretend() {

--- a/x11-drivers/xf86-video-vmware/xf86-video-vmware-9999.ebuild
+++ b/x11-drivers/xf86-video-vmware/xf86-video-vmware-9999.ebuild
@@ -9,7 +9,7 @@ inherit xlibre
 
 DESCRIPTION="VMware SVGA video driver"
 if [[ ${PV} != 9999* ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 
 RDEPEND="


### PR DESCRIPTION
@metux Could you also take a look at these:
https://github.com/X11Libre/xf86-input-mouse/pull/1
https://github.com/X11Libre/xf86-input-keyboard/pull/1

There pr's bring back linux support to these drivers.
Without this, they are useless on linux.