### PR TITLE
treewide: Harmonize with Gentoo ebuilds

### DIFF
--- a/x11-base/xlibre-drivers/metadata.xml
+++ b/x11-base/xlibre-drivers/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>maintainer-needed@example.com</email>
-    <name>XLibre</name>
-  </maintainer>
+	<maintainer type="project">
+		<email>maintainer-needed@example.com</email>
+		<name>XLibre</name>
+	</maintainer>
 </pkgmetadata>

--- a/x11-base/xlibre-drivers/xlibre-drivers-9999.ebuild
+++ b/x11-base/xlibre-drivers/xlibre-drivers-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Meta package containing deps on all xlibre drivers"
-HOMEPAGE="No_homepage"
+HOMEPAGE="https://github.com/X11Libre/ports-gentoo"
 
 LICENSE="metapackage"
 SLOT="0"

--- a/x11-base/xlibre-server/metadata.xml
+++ b/x11-base/xlibre-server/metadata.xml
@@ -14,4 +14,7 @@
     <flag name="xorg">Build the Xorg X server (HIGHLY RECOMMENDED)</flag>
     <flag name="xvfb">Build the Xvfb server</flag>
   </use>
+  <upstream>
+    <remote-id type="github">X11Libre/xserver</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 XLIBRE_EAUTORECONF="no"
 
 inherit flag-o-matic xlibre meson
+EGIT_REPO_URI="https://github.com/X11Libre/xserver.git"
 
 DESCRIPTION="XLibre X servers"
 SLOT="0/${PV}"
-
-# This is the only ebuild for now, keep keywords
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi

--- a/x11-drivers/xf86-input-elographics/xf86-input-elographics-9999.ebuild
+++ b/x11-drivers/xf86-input-elographics/xf86-input-elographics-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="Elographics input driver"

--- a/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
+++ b/x11-drivers/xf86-input-evdev/xf86-input-evdev-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit linux-info xlibre
 
 DESCRIPTION="Generic Linux input driver"

--- a/x11-drivers/xf86-input-joystick/xf86-input-joystick-9999.ebuild
+++ b/x11-drivers/xf86-input-joystick/xf86-input-joystick-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="XLibre driver for joystick input devices"

--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-9999.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-9999.ebuild
@@ -3,8 +3,9 @@
 
 EAPI=8
 
-
 inherit linux-info xlibre
+
+DESCRIPTION="X.org input driver based on libinput"
 
 DESCRIPTION="XLibre input driver based on libinput"
 if [[ ${PV} != 9999* ]]; then

--- a/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-9999.ebuild
+++ b/x11-drivers/xf86-input-synaptics/xf86-input-synaptics-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit linux-info xlibre
 
 DESCRIPTION="Driver for Synaptics touchpads"

--- a/x11-drivers/xf86-video-ast/xf86-video-ast-9999.ebuild
+++ b/x11-drivers/xf86-video-ast/xf86-video-ast-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="XLibre driver for ASpeedTech cards"

--- a/x11-drivers/xf86-video-dummy/xf86-video-dummy-9999.ebuild
+++ b/x11-drivers/xf86-video-dummy/xf86-video-dummy-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="XLibre driver for dummy cards"

--- a/x11-drivers/xf86-video-geode/xf86-video-geode-9999.ebuild
+++ b/x11-drivers/xf86-video-geode/xf86-video-geode-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="AMD Geode GX and LX graphics driver"

--- a/x11-drivers/xf86-video-mga/xf86-video-mga-9999.ebuild
+++ b/x11-drivers/xf86-video-mga/xf86-video-mga-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="Matrox video driver"

--- a/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-9999.ebuild
+++ b/x11-drivers/xf86-video-nouveau/xf86-video-nouveau-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 XLIBRE_DRI="always"
-
 inherit xlibre
 
 DESCRIPTION="Accelerated Open Source driver for nVidia cards"

--- a/x11-drivers/xf86-video-qxl/xf86-video-qxl-9999.ebuild
+++ b/x11-drivers/xf86-video-qxl/xf86-video-qxl-9999.ebuild
@@ -4,10 +4,10 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-
 inherit python-single-r1 xlibre
 
 DESCRIPTION="QEMU QXL paravirt video driver"
+
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~amd64 ~loong ~x86"
 fi

--- a/x11-drivers/xf86-video-r128/xf86-video-r128-9999.ebuild
+++ b/x11-drivers/xf86-video-r128/xf86-video-r128-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit flag-o-matic xlibre
 
 DESCRIPTION="ATI Rage128 video driver"

--- a/x11-drivers/xf86-video-siliconmotion/xf86-video-siliconmotion-9999.ebuild
+++ b/x11-drivers/xf86-video-siliconmotion/xf86-video-siliconmotion-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit xlibre
 
 DESCRIPTION="Silicon Motion video driver"

--- a/x11-drivers/xf86-video-vesa/xf86-video-vesa-9999.ebuild
+++ b/x11-drivers/xf86-video-vesa/xf86-video-vesa-9999.ebuild
@@ -3,7 +3,6 @@
 
 EAPI=8
 
-
 inherit linux-info xlibre
 
 DESCRIPTION="Generic VESA video driver"

--- a/x11-drivers/xf86-video-vmware/xf86-video-vmware-9999.ebuild
+++ b/x11-drivers/xf86-video-vmware/xf86-video-vmware-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 XLIBRE_DRI=always
-
 inherit xlibre
 
 DESCRIPTION="VMware SVGA video driver"
@@ -15,6 +14,6 @@ fi
 RDEPEND="
 	kernel_linux? (
 		>=x11-libs/libdrm-2.4.96[video_cards_vmware]
-		media-libs/mesa
+		media-libs/mesa[xa]
 	)"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
* Fixed homepage of x11-base/xlibre-drivers
* Readded EGIT_REPO_URI to x11-base/xlibre-server
* Readded upstream remote-id to x11-base/xlibre-server
* Readded xa use flag to media-libs/mesa dependency of x11-drivers/xf86-video-vmware
* Adjusted some whitespace

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
