### PR TITLE
x11-drivers/xf86-input-void: readd, v9999

### DIFF
--- a/x11-drivers/xf86-input-void/metadata.xml
+++ b/x11-drivers/xf86-input-void/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>maintainer-needed@example.com</email>
+    <name>XLibre</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">X11Libre/xf86-input-void</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/x11-drivers/xf86-input-void/xf86-input-void-9999.ebuild
+++ b/x11-drivers/xf86-input-void/xf86-input-void-9999.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xlibre
+
+DESCRIPTION="null input driver"
+
+if [[ ${PV} != 9999* ]]; then
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi


### PR DESCRIPTION
* Readd since it got lost when setting up this repository

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
