### PR TITLE
README.md: documented EGIT_OVERRIDEs and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You may want to adjust the [priority](https://wiki.gentoo.org/wiki//etc/portage/
 ```
 [xlibre]
 ...
-priority = 9999
+priority = 100
 ...
 ```
 
@@ -38,7 +38,13 @@ installing `x11-base/xlibre-server` and the `x11-base/xorg-server::xlibre` dummy
 
 ## Using the overlay
 
-Right now there is no released version of XLibre Xserver. To use the XLibre Git live ebuilds, add the following lines to your `/etc/portage/package.accept_keywords`[1](https://wiki.gentoo.org/wiki//etc/portage/package.accept_keywords) file:
+Right now there is no released version of XLibre Xserver. To use the XLibre [live ebuilds](https://wiki.gentoo.org/wiki/Live_ebuilds), add the following lines to your [/etc/portage/package.accept\_keywords](https://wiki.gentoo.org/wiki//etc/portage/package.accept_keywords) file:
+
+```
+*/*::xlibre **
+```
+
+**Or** for the individual packages:
 
 ```
 x11-base/xlibre-drivers **
@@ -49,6 +55,7 @@ x11-drivers/xf86-input-evdev **
 x11-drivers/xf86-input-joystick **
 x11-drivers/xf86-input-libinput **
 x11-drivers/xf86-input-synaptics **
+x11-drivers/xf86-input-void **
 x11-drivers/xf86-input-vmmouse **
 x11-drivers/xf86-input-wacom **
 x11-drivers/xf86-video-amdgpu **
@@ -67,6 +74,36 @@ x11-drivers/xf86-video-vesa **
 x11-drivers/xf86-video-vmware **
 ```
 
-If `/etc/portage/package.accept_keywords` is a directory, then create a file `/etc/portage/package.accept_keywords/xlibre` with the above content.
+If `/etc/portage/package.accept_keywords` is a directory, then create a file like `/etc/portage/package.accept_keywords/xlibre` containing one of the above blocks.
 
 **WARNING:** The live ebuilds may break at any time. Use them only if you want to develop or alpha test XLibre. If in doubt, wait for the first release.
+
+## Testing Third-Party Repositories Added as a Pull Request
+
+To build pull requests from third-party repositories using the Git live ebuilds you can override the Git repo, branch and commit values set in the ebuild. Just provide one or more of the following variables on the command line:
+
+```
+EGIT_OVERRIDE_REPO_*
+EGIT_OVERRIDE_BRANCH_*
+EGIT_OVERRIDE_COMMIT_*
+```
+
+For example:
+
+```
+EGIT_OVERRIDE_REPO_X11LIBRE_XSERVER="https://github.com/probonopd/xserver" EGIT_OVERRIDE_BRANCH_X11LIBRE_XSERVER="patch-2"  emerge -1 x11-base/xlibre-server
+```
+
+where in this example `X11LIBRE` is the capitalized name of the Github project and `XSERVER` is the capitalized name of the Github repository of the live ebuild.
+
+You will see the actual names of the variables specific to each ebuild when you unpack it, e.g.:
+
+```
+# ebuild xlibre-server-9999.ebuild unpack
+```
+
+For further reference of the override mechanism see [git-r3.eclass – Gentoo Development Guide](https://devmanual.gentoo.org/eclass-reference/git-r3.eclass/index.html) and its implementation.
+
+## Using an Alternative udev Implementation
+
+If you like to use XLibre with udev support but stay away from eudev/systemd you may want to consider [sys-libs/libudev-zero - Gentoo Portage Overlays](https://gpo.zugaina.org/sys-libs/libudev-zero).


### PR DESCRIPTION
* added documentation for using EGIT_OVERRIDEs in the live ebuilds,
  fixes gh-8
* added simplified expression for unmasking live ebuilds, fixes gh-15
* added x11-drivers/xf86-input-void to list of unmaskable live ebuilds
* added link to live ebuilds documentation on Gentoo Wiki
* mentioned libudev-zero as an alternative to eudev/systemd, fixes gh-15
* some minor improvements

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
