### PR TITLE
x11-drivers/xf86-video-amdgpu: Fixed ebuild, gh-17

### DIFF
--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -6,6 +6,8 @@ XLIBRE_DRI="always"
 
 inherit xlibre
 
+EGIT_BRANCH="master"
+
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
 fi


### PR DESCRIPTION
* Made the ebuild to pull from `master` branch instead of 9 years old
  default branach `1.0` using an outdated API. Fixes gh-17

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
