### PR TITLE
x11-base/xlibre-server: readd Gentoo patches, #21

### DIFF
--- a/x11-base/xlibre-server/files/xlibre-server-1.12-unloadsubmodule.patch
+++ b/x11-base/xlibre-server/files/xlibre-server-1.12-unloadsubmodule.patch
@@ -1,0 +1,53 @@
+diff -u13 -r xorg-server-1.12.3-old/hw/xfree86/loader/loadmod.c xorg-server-1.12.3/hw/xfree86/loader/loadmod.c
+--- xorg-server-1.12.3-old/hw/xfree86/loader/loadmod.c	2012-09-05 18:26:42.000000000 +0200
++++ xorg-server-1.12.3/hw/xfree86/loader/loadmod.c	2012-09-05 18:28:54.000000000 +0200
+@@ -1109,39 +1109,38 @@
+ static void
+ RemoveChild(ModuleDescPtr child)
+ {
+     ModuleDescPtr mdp;
+     ModuleDescPtr prevsib;
+     ModuleDescPtr parent;
+ 
+     if (!child->parent)
+         return;
+ 
+     parent = child->parent;
+     if (parent->child == child) {
+         parent->child = child->sib;
+-        return;
+-    }
+-
+-    prevsib = parent->child;
+-    mdp = prevsib->sib;
+-    while (mdp && mdp != child) {
+-        prevsib = mdp;
+-        mdp = mdp->sib;
++    }
++    else {
++        prevsib = parent->child;
++        mdp = prevsib->sib;
++        while (mdp && mdp != child) {
++            prevsib = mdp;
++            mdp = mdp->sib;
++        }
++        if (mdp == child)
++            prevsib->sib = child->sib;
+     }
+-    if (mdp == child)
+-        prevsib->sib = child->sib;
+     child->sib = NULL;
+-    return;
+ }
+ 
+ void
+ LoaderErrorMsg(const char *name, const char *modname, int errmaj, int errmin)
+ {
+     const char *msg;
+     MessageType type = X_ERROR;
+ 
+     switch (errmaj) {
+     case LDR_NOERROR:
+         msg = "no error";
+         break;
+     case LDR_NOMEM:

--- a/x11-base/xlibre-server/files/xlibre-server-1.18-support-multiple-Files-sections.patch
+++ b/x11-base/xlibre-server/files/xlibre-server-1.18-support-multiple-Files-sections.patch
@@ -1,0 +1,53 @@
+See http://lists.x.org/archives/xorg-devel/2015-February/045755.html
+
+diff --git a/hw/xfree86/parser/Files.c b/hw/xfree86/parser/Files.c
+index 849bf92..5cc3ec7 100644
+--- a/hw/xfree86/parser/Files.c
++++ b/hw/xfree86/parser/Files.c
+@@ -76,14 +76,18 @@ static xf86ConfigSymTabRec FilesTab[] = {
+ #define CLEANUP xf86freeFiles
+ 
+ XF86ConfFilesPtr
+-xf86parseFilesSection(void)
++xf86parseFilesSection(XF86ConfFilesPtr ptr)
+ {
+     int i, j;
+     int k, l;
+     char *str;
+     int token;
+ 
+-    parsePrologue(XF86ConfFilesPtr, XF86ConfFilesRec)
++    if (!ptr) {
++	if( (ptr=calloc(1,sizeof(XF86ConfFilesRec))) == NULL ) {
++		return NULL;
++	}
++    }
+ 
+         while ((token = xf86getToken(FilesTab)) != ENDSECTION) {
+         switch (token) {
+diff --git a/hw/xfree86/parser/configProcs.h b/hw/xfree86/parser/configProcs.h
+index 171f8e8..e8199fe 100644
+--- a/hw/xfree86/parser/configProcs.h
++++ b/hw/xfree86/parser/configProcs.h
+@@ -36,7 +36,7 @@ void xf86freeDeviceList(XF86ConfDevicePtr ptr);
+ int xf86validateDevice(XF86ConfigPtr p);
+ 
+ /* Files.c */
+-XF86ConfFilesPtr xf86parseFilesSection(void);
++XF86ConfFilesPtr xf86parseFilesSection(XF86ConfFilesPtr ptr);
+ void xf86printFileSection(FILE * cf, XF86ConfFilesPtr ptr);
+ void xf86freeFiles(XF86ConfFilesPtr p);
+ 
+diff --git a/hw/xfree86/parser/read.c b/hw/xfree86/parser/read.c
+index 327c02a..e0d6139 100644
+--- a/hw/xfree86/parser/read.c
++++ b/hw/xfree86/parser/read.c
+@@ -110,7 +110,7 @@ xf86readConfigFile(void)
+             if (xf86nameCompare(xf86_lex_val.str, "files") == 0) {
+                 free(xf86_lex_val.str);
+                 xf86_lex_val.str = NULL;
+-                HANDLE_RETURN(conf_files, xf86parseFilesSection());
++                HANDLE_RETURN(conf_files, xf86parseFilesSection(ptr->conf_files));
+             }
+             else if (xf86nameCompare(xf86_lex_val.str, "serverflags") == 0) {
+                 free(xf86_lex_val.str);

--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -94,6 +94,13 @@ REQUIRED_USE="!minimal? (
 	elogind? ( udev )
 	?? ( elogind systemd )"
 
+PATCHES=(
+	"${UPSTREAMED_PATCHES[@]}"
+	"${FILESDIR}"/${PN}-1.12-unloadsubmodule.patch
+	# needed for new eselect-opengl, bug #541232
+	"${FILESDIR}"/${PN}-1.18-support-multiple-Files-sections.patch
+)
+
 src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2


### PR DESCRIPTION
During the initial merge #2 the Gentoo patches of the
x11-base/xorg-server-9999 got lost. Readd them since they still apply.

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
