### PR TITLE
treewide: set S in xlibre.eclass

### DIFF
--- a/eclass/xlibre.eclass
+++ b/eclass/xlibre.eclass
@@ -122,6 +122,7 @@ if [[ ${PV} == *9999* ]]; then
 	: "${EGIT_REPO_URI:="https://github.com/X11Libre/${XLIBRE_MODULE}${XLIBRE_PACKAGE_NAME}.git"}"
 elif [[ -n ${XLIBRE_BASE_INDIVIDUAL_URI} ]]; then
 	SRC_URI="${XLIBRE_BASE_INDIVIDUAL_URI}/${XLIBRE_PACKAGE_NAME}/archive/refs/tags/xlibre-${XLIBRE_PACKAGE_NAME}-${PV}.tar.${XLIBRE_TARBALL_SUFFIX}"
+	S="${WORKDIR}/${XLIBRE_PACKAGE_NAME}-xlibre-${XLIBRE_PACKAGE_NAME}-${PV}"
 fi
 
 : "${SLOT:=0}"

--- a/x11-base/xlibre-server/xlibre-server-25.0.0.0.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-25.0.0.0.ebuild
@@ -12,7 +12,6 @@ SLOT="0/${PV}"
 
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
-	S="${WORKDIR}/xserver-xlibre-xserver-${PV}"
 fi
 
 IUSE_SERVERS="xephyr xnest xorg xvfb"

--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -12,7 +12,6 @@ DESCRIPTION="XLibre X servers"
 SLOT="0/${PV}"
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
-	S="${WORKDIR}/xserver-xlibre-xserver-${PV}"
 fi
 
 IUSE_SERVERS="xephyr xnest xorg xvfb"


### PR DESCRIPTION
* set the S variable to a sane default in xlibre.eclass so it doesn't
  have to be set in the individual ebuilds

Fixes #23

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
