### PR TITLE
x11-base: remove old ewarn from xlibre-server

### DIFF
--- a/x11-base/xlibre-server/xlibre-server-25.0.0.0.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-25.0.0.0.ebuild
@@ -175,8 +175,6 @@ src_install() {
 	ln -rsf "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions "${ED}"/usr/$(get_libdir)/xorg/modules/extensions
 
 	ewarn "If this is the first time you installed xlibre, you have to emerge @x11-module-rebuild"
-	ewarn "Something in your @world likely depends on xorg-server"
-	ewarn "Add x11-base/xorg-server-9999 to /etc/portage/profile/package.provided to fix this"
 }
 
 pkg_postrm() {

--- a/x11-base/xlibre-server/xlibre-server-25.0.0.1.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-25.0.0.1.ebuild
@@ -175,8 +175,6 @@ src_install() {
 	ln -rsf "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions "${ED}"/usr/$(get_libdir)/xorg/modules/extensions
 
 	ewarn "If this is the first time you installed xlibre, you have to emerge @x11-module-rebuild"
-	ewarn "Something in your @world likely depends on xorg-server"
-	ewarn "Add x11-base/xorg-server-9999 to /etc/portage/profile/package.provided to fix this"
 }
 
 pkg_postrm() {

--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -182,8 +182,6 @@ src_install() {
 	ln -rsf "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions "${ED}"/usr/$(get_libdir)/xorg/modules/extensions
 
 	ewarn "If this is the first time you installed xlibre, you have to emerge @x11-module-rebuild"
-	ewarn "Something in your @world likely depends on xorg-server"
-	ewarn "Add x11-base/xorg-server-9999 to /etc/portage/profile/package.provided to fix this"
 }
 
 pkg_postrm() {


### PR DESCRIPTION
I had this in the ebuild in my overlay because I didn't write a dummy xorg-server ebuild.
This isn't the case here. As such, the old ewarn is misleading here.

@callmetango thoughts?