### PR TITLE
Add xf86-input-{keyboard,mouse} ebuilds

### DIFF
--- a/x11-base/xlibre-drivers/xlibre-drivers-9999.ebuild
+++ b/x11-base/xlibre-drivers/xlibre-drivers-9999.ebuild
@@ -18,7 +18,9 @@ IUSE_INPUT_DEVICES="
 	input_devices_elographics
 	input_devices_evdev
 	input_devices_joystick
+	input_devices_keyboard
 	input_devices_libinput
+	input_devices_mouse
 	input_devices_vmmouse
 	input_devices_void
 	input_devices_synaptics
@@ -59,10 +61,12 @@ PDEPEND="
 								 >=x11-drivers/xf86-input-evdev-2.10.6
 							   )
 	input_devices_joystick?    ( >=x11-drivers/xf86-input-joystick-1.6.3 )
+	input_devices_keyboard?    ( x11-drivers/xf86-input-keyboard )
 	input_devices_libinput?    (
 								 >=x11-base/xlibre-server-${PV}[udev]
 								 >=x11-drivers/xf86-input-libinput-0.27.1
 							   )
+	input_devices_mouse?       ( x11-drivers/xf86-input-mouse )
 	input_devices_vmmouse?     ( x11-drivers/xf86-input-vmmouse )
 	input_devices_void?        ( x11-drivers/xf86-input-void )
 	input_devices_synaptics?   ( x11-drivers/xf86-input-synaptics )

--- a/x11-drivers/xf86-input-keyboard/metadata.xml
+++ b/x11-drivers/xf86-input-keyboard/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>maintainer-needed@example.com</email>
+    <name>XLibre</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">X11Libre/xf86-input-keyboard</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/x11-drivers/xf86-input-keyboard/xf86-input-keyboard-9999.ebuild
+++ b/x11-drivers/xf86-input-keyboard/xf86-input-keyboard-9999.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xlibre
+
+DESCRIPTION="Keyboard input driver"
+if [[ ${PV} != 9999* ]]; then
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+fi
+
+RDEPEND="x11-base/xlibre-server"
+DEPEND="${RDEPEND}"

--- a/x11-drivers/xf86-input-mouse/metadata.xml
+++ b/x11-drivers/xf86-input-mouse/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>maintainer-needed@example.com</email>
+    <name>XLibre</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">X11Libre/xf86-input-mouse</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/x11-drivers/xf86-input-mouse/xf86-input-mouse-9999.ebuild
+++ b/x11-drivers/xf86-input-mouse/xf86-input-mouse-9999.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xlibre
+
+DESCRIPTION="Mouse input driver"
+if [[ ${PV} != 9999* ]]; then
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+fi
+
+RDEPEND="x11-base/xlibre-server"
+DEPEND="${RDEPEND}"


### PR DESCRIPTION
These drivers work even on machines that don't have evdev support.
These also don't need udev or any libudev implementation.

@callmetango thoughts?