### PR TITLE
x11-base/xlibre-server-9999: drop multiple config files section patch

### DIFF
--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -9,6 +9,7 @@ inherit flag-o-matic xlibre-meson
 EGIT_REPO_URI="https://github.com/X11Libre/xserver.git"
 
 DESCRIPTION="XLibre X servers"
+HOMEPAGE="https://github.com/X11Libre/xserver"
 SLOT="0/${PV}"
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
@@ -97,8 +98,6 @@ REQUIRED_USE="!minimal? (
 PATCHES=(
 	"${UPSTREAMED_PATCHES[@]}"
 	"${FILESDIR}"/${PN}-1.12-unloadsubmodule.patch
-	# needed for new eselect-opengl, bug #541232
-	"${FILESDIR}"/${PN}-1.18-support-multiple-Files-sections.patch
 )
 
 src_configure() {


### PR DESCRIPTION
The patch has been merged upstream.

References:
https://github.com/X11Libre/xserver/pull/491

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
