### PR TITLE
x11-base/xlibre-server-9999: added xinerama use flag, simplified keepdir

### DIFF
--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} != 9999* ]]; then
 fi
 
 IUSE_SERVERS="xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug +elogind minimal selinux suid systemd test +udev unwind xcsecurity"
+IUSE="${IUSE_SERVERS} debug +elogind minimal selinux suid systemd test +udev unwind xcsecurity xinerama"
 RESTRICT="!test? ( test )"
 
 CDEPEND="
@@ -125,6 +125,7 @@ src_configure() {
 		$(meson_use xcsecurity)
 		$(meson_use selinux xselinux)
 		$(meson_use xephyr)
+		$(meson_use xinerama)
 		$(meson_use xnest)
 		$(meson_use xorg)
 		$(meson_use xvfb)
@@ -178,20 +179,13 @@ src_install() {
 	newins "${FILESDIR}"/xlibre-sets.conf xlibre.conf
 
 	# Create these in case they weren't already installed
-	mkdir -p "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/drivers
-	mkdir -p "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/input
-	mkdir -p "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions
+	keepdir /usr/$(get_libdir)/xorg/modules/xlibre-25/drivers
+	keepdir /usr/$(get_libdir)/xorg/modules/xlibre-25/input
+	keepdir /usr/$(get_libdir)/xorg/modules/xlibre-25/extensions
 
-	# Portage doesn't install empty directories
-	# https://blogs.gentoo.org/mgorny/2018/05/20/empty-directories-into-dodir-keepdir-and-tmpfiles-d/
-	touch "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/drivers/.keep
-	touch "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/input/.keep
-	touch "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions/.keep
-
-	# Symlinks so that drivers are installed where they should be
-	ln -rsf "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/drivers "${ED}"/usr/$(get_libdir)/xorg/modules/drivers
-	ln -rsf "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/input "${ED}"/usr/$(get_libdir)/xorg/modules/input
-	ln -rsf "${ED}"/usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions "${ED}"/usr/$(get_libdir)/xorg/modules/extensions
+	keepdir /usr/$(get_libdir)/xorg/modules/xlibre-25.0/drivers
+	keepdir /usr/$(get_libdir)/xorg/modules/xlibre-25.0/input
+	keepdir /usr/$(get_libdir)/xorg/modules/xlibre-25.0/extensions
 
 	ewarn "If this is the first time you installed xlibre, you have to emerge @x11-module-rebuild"
 }


### PR DESCRIPTION
* Added the xinerama use flag since building without xinerama has been
  fixed in X11Libre/xserver/issues/657.
* Simplified the keepdirs and added the xlibre-25 ones

Signed-off-by: callmetango <callmetango@users.noreply.github.com>
