### PR TITLE
xlibre-server: add xfbdev use flag

### DIFF
--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
-IUSE_SERVERS="xephyr xnest xorg xvfb"
+IUSE_SERVERS="xephyr xfbdev xnest xorg xvfb"
 IUSE="${IUSE_SERVERS} debug +elogind minimal selinux suid systemd test +udev unwind xcsecurity +xinerama"
 RESTRICT="!test? ( test )"
 
@@ -124,6 +124,7 @@ src_configure() {
 		$(meson_use xcsecurity)
 		$(meson_use selinux xselinux)
 		$(meson_use xephyr)
+		$(meson_use xfbdev)
 		$(meson_use xinerama)
 		$(meson_use xnest)
 		$(meson_use xorg)
@@ -165,6 +166,12 @@ src_install() {
 			chmod u+s "${ED}"/usr/bin/Xorg
 		fi
 	fi
+
+	# Xfbdev should always be installed suid
+	if use xfbdev; then
+		chmod 4755 "${ED}"/usr/bin/Xfbdev
+	fi
+
 
 	if ! use xorg; then
 		rm -f "${ED}"/usr/share/man/man1/Xserver.1x \

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -13,8 +13,8 @@ if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
-IUSE_SERVERS="xephyr xnest xorg xvfb"
-IUSE="${IUSE_SERVERS} debug +elogind minimal selinux suid systemd test +udev unwind xcsecurity"
+IUSE_SERVERS="xephyr xfbdev xnest xorg xvfb"
+IUSE="${IUSE_SERVERS} debug +elogind minimal selinux suid systemd test +udev unwind xcsecurity xinerama"
 RESTRICT="!test? ( test )"
 
-DEPEND="x11-base/xlibre-server:${SLOT}[xephyr=,xnest=,xorg=,xvfb=,debug=,elogind=,minimal=,selinux=,suid=,systemd=,test=,udev=,unwind=,xcsecurity=]"
+DEPEND="x11-base/xlibre-server:${SLOT}[xephyr=,xfbdev=,xnest=,xorg=,xvfb=,debug=,elogind=,minimal=,selinux=,suid=,systemd=,test=,udev=,unwind=,xcsecurity=,xinerama=]"


### PR DESCRIPTION
@callmetango The xinerama use flag is present only in the xlibre-server ebuilds, but not in the xorg-server ebuilds.

I did the same with xfbdev. Should we keep it like this, or should we add in to xorg-server too?