### PR TITLE
Add unstable ebuild for xf86-input-libinput

### DIFF
--- a/x11-drivers/xf86-input-libinput/xf86-input-libinput-1.5.1.0.ebuild
+++ b/x11-drivers/xf86-input-libinput/xf86-input-libinput-1.5.1.0.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info xlibre autotools
+
+DESCRIPTION="XLibre input driver based on libinput"
+HOMEPAGE="https://github.com/X11Libre/xf86-input-libinput"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+RDEPEND=">=dev-libs/libinput-1.23.0:0="
+DEPEND="${RDEPEND}
+	>=x11-base/xorg-proto-2021.5"
+
+DOCS=( "README.md" )
+
+src_prepare() {
+	eautoreconf
+	default
+}
+
+pkg_pretend() {
+	CONFIG_CHECK="~TIMERFD"
+	check_extra_config
+}


### PR DESCRIPTION
This adds an unstable ebuild for the latest release. I have tested it and it compiles for me.

I am sorry if the ebuild has issues.