### PR TITLE
x11-base/xlibre-server: drop unloadsubmodule patch

### DIFF
--- a/x11-base/xlibre-server/xlibre-server-9999.ebuild
+++ b/x11-base/xlibre-server/xlibre-server-9999.ebuild
@@ -95,10 +95,6 @@ REQUIRED_USE="!minimal? (
 	elogind? ( udev )
 	?? ( elogind systemd )"
 
-PATCHES=(
-	"${UPSTREAMED_PATCHES[@]}"
-	"${FILESDIR}"/${PN}-1.12-unloadsubmodule.patch
-)
 
 src_configure() {
 	# bug #835653


### PR DESCRIPTION
Patch was merged: https://github.com/X11Libre/xserver/pull/1317